### PR TITLE
Add ambient module definitions

### DIFF
--- a/src/commands/fixtures.ts
+++ b/src/commands/fixtures.ts
@@ -1,5 +1,4 @@
-// tslint:disable-next-line
-const figlet = require('figlet');
+import * as figlet from 'figlet';
 import * as api from '../api';
 import cfg from '../config';
 import { getLeagueByCode } from '../constants/leagues';

--- a/src/commands/standings.ts
+++ b/src/commands/standings.ts
@@ -1,5 +1,4 @@
-// tslint:disable-next-line
-const figlet = require('figlet');
+import * as figlet from 'figlet';
 import * as api from '../api';
 import cfg from '../config';
 import { getLeagueByCode } from '../constants/leagues';

--- a/src/commands/team.ts
+++ b/src/commands/team.ts
@@ -1,5 +1,4 @@
-// tslint:disable-next-line
-const figlet = require('figlet');
+import * as figlet from 'figlet';
 import * as api from '../api';
 import cfg from '../config';
 import { Fixture, Player, Team } from '../models';

--- a/src/constants/questions.ts
+++ b/src/constants/questions.ts
@@ -1,7 +1,6 @@
 import * as inquirer from 'inquirer';
+import * as autocomplete from 'inquirer-autocomplete-prompt';
 import { ILeague, leagueCodes } from './leagues';
-// tslint:disable-next-line
-const autocomplete = require('inquirer-autocomplete-prompt');
 inquirer.registerPrompt('autocomplete', autocomplete);
 
 const searchLeague = (_: any, input: string) => {

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -1,0 +1,6 @@
+// Packages without type definitions.
+declare module 'figlet';
+declare module 'inquirer-autocomplete-prompt';
+
+// Binary assets and text-based files.
+declare module '*.json';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,10 @@
 #!/usr/bin/env node
 
-import * as inquirer from 'inquirer';
-// tslint:disable-next-line
-const pkg = require('../package.json');
 import * as Chalk from 'chalk';
 import * as program from 'commander';
+import * as inquirer from 'inquirer';
 import * as UpdateNotifier from 'update-notifier';
+import * as pkg from '../package.json';
 import * as commands from './commands';
 import { getLeagueByName } from './constants/leagues';
 import { questions } from './constants/questions';


### PR DESCRIPTION
Dependencies that do not provide type definitions (e.g. `figlet`) and text-based files (e.g. `package.json`) now have [ambient module definitions](https://www.typescriptlang.org/docs/handbook/modules.html#working-with-other-javascript-libraries). This allows to import them using the ES2015 syntax instead of using `require()`.

Ultimately this brings cleaner code by keeping a consistent import style instead of using mixed approaches.