### PR TITLE
Fixed cache location

### DIFF
--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -1,8 +1,7 @@
 import axios, { AxiosRequestConfig } from 'axios';
 import Cache from './Cache';
 
-const baseDir = process.cwd();
-const cache = new Cache(baseDir);
+const cache = new Cache(__dirname);
 
 export const cachedApiCall = async (
   url: string,


### PR DESCRIPTION
Until now, the cache file was created in the current working directory, which had some undesired behaviours:
- For the caching strategy to work, the user had to invoke the application always from the same directory.
- A cache file would have been created in each directory from which the app was initiated.
- The application would have crashed if it was called from a directory where the user didn't have write permissions (inability to create the cache file).

This PR fixes the above-described issues by using [`__dirname`](https://nodejs.org/docs/latest/api/modules.html#modules_dirname) as the base directory for the cache file. By doing so the cache is consistently created in the `Cache` module directory.