### PR TITLE
Use proper platform-specific cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ lib_test
 .vscode/
 .idea/
 yarn-error.log
-.cache
+cache

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -1,8 +1,9 @@
 import p from 'phin'
 import Cache from './Cache'
 import { JSONValue } from './CacheItem'
+import { getCacheDir } from '../utils/system-paths'
 
-const cache = new Cache(__dirname)
+const cache = new Cache(getCacheDir())
 
 export async function cachedApiCall(
   url: string,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -9,6 +9,6 @@ export default {
       standings: 60 * 60 * 1000, // 1 hour
       team: 7 * 24 * 60 * 60 * 1000, // 1 week
     },
-    fileName: '.cache',
+    fileName: 'cache',
   },
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,12 @@
+/**
+ * Asserts if a alleged `error` is a Node.js system error.
+ */
+export const isErrorNodeSystemError = (error: unknown): error is NodeJS.ErrnoException => {
+  return (
+    'code' in (error as never) &&
+    'errno' in (error as never) &&
+    'code' in (error as never) &&
+    'path' in (error as never) &&
+    'syscall' in (error as never)
+  )
+}

--- a/src/utils/system-paths.ts
+++ b/src/utils/system-paths.ts
@@ -1,0 +1,56 @@
+import os from 'os'
+import fs from 'fs'
+import path from 'path'
+import { isErrorNodeSystemError } from './errors'
+
+const APP_CACHE_DIR_NAME = 'soccer-go'
+
+/**
+ * Gets the platform-specific, user-space cache directory path.
+ *
+ * This function covers the three main platforms: linux, macOS, and Windows.
+ * Other platforms might have other directory conventions but, for now, a
+ * temporary directory will suffice.
+ */
+const getPlatformSpecificCacheDirPath = (): string => {
+  const homePath = os.homedir()
+
+  switch (os.platform()) {
+    case 'linux': {
+      return path.join(homePath, '.cache', APP_CACHE_DIR_NAME)
+    }
+
+    case 'darwin': {
+      return path.join(homePath, 'Library', 'Caches', APP_CACHE_DIR_NAME)
+    }
+
+    case 'win32': {
+      return path.join(homePath, 'AppData', 'Local', 'Temp', APP_CACHE_DIR_NAME)
+    }
+
+    default: {
+      // Not sure yet what is the standard approach to app caching on other
+      // platforms, so use a temporary folder.
+      return path.join(os.tmpdir(), APP_CACHE_DIR_NAME)
+    }
+  }
+}
+
+/**
+ * Gets the application's cache directory path.
+ *
+ * If required, this function will also initialize the directory.
+ */
+export const getCacheDir = (): string => {
+  const cacheDirPath = getPlatformSpecificCacheDirPath()
+
+  try {
+    fs.statSync(cacheDirPath)
+  } catch (e: unknown) {
+    if (isErrorNodeSystemError(e) && e.code === 'ENOENT') {
+      fs.mkdirSync(cacheDirPath, { recursive: true })
+    }
+  }
+
+  return cacheDirPath
+}


### PR DESCRIPTION
This PR adds `getCacheDir`, a function that returns a user-space, platform-specific cache directory that is used when creating an instance of `Cache`.

Not only this offers a consistent path for cache data, it also allows operating systems to correctly clear cached data in accordance with their default behavior or by a user's explicit request.

The directories are:
- Linux: `$HOME/.cache/soccer-go`
- OSX/macOS: `$HOME/Library/Caches/soccer-go`
- Windows: `%USERPROFILE%\AppData\Local\Temp\soccer-go`
- Other platforms: `/path/to/temp/dir/soccer-go`

Note that only the three major platforms are properly implemented. For all other cases, a system temporary directory is used instead. We can expand on this in the future if we see need for it.

Also, because these specific cache directories are hidden by default, there is no need to have a dot prefix for the cache file name, so it was removed.

## macOS testing needed ⚠️ 
I tested these changes on Linux and Windows 11 without issues, but I don't have a macOS machine to check there too. You should try that before merging this.