### PR TITLE
Improve error management

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -57,11 +57,12 @@ export async function getTeamId(teamName: string, leagueCode: string): Promise<n
 }
 
 async function callApi(url: string, placeholder: string, expiry: number): Promise<any> {
-  if (!cfg.authToken) {
-    apiKeyError()
+  const spinner = createSpinner(placeholder).start()
+  if (!cfg.authToken && !process.env.CI) {
+    spinner.error()
+    throw new ApplicationError(ErrorCode.API_KEY_MISSING)
   }
 
-  const spinner = createSpinner(placeholder).start()
   try {
     const response = await cachedApiCall(url, cfg.authToken, expiry)
     spinner.success().clear()
@@ -77,12 +78,4 @@ async function callApi(url: string, placeholder: string, expiry: number): Promis
     }
     throw error
   }
-}
-
-function apiKeyError(): void {
-  if (process.env.CI) {
-    return
-  }
-
-  throw new ApplicationError(ErrorCode.API_KEY_MISSING)
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -3,6 +3,7 @@ import { createSpinner } from 'nanospinner'
 import { cachedApiCall } from './cache'
 import cfg from './config'
 import { IFixtureJson, IStandingsJson, ITeamJson, Team } from './models'
+import { ApplicationError, ErrorCode } from './utils/errors'
 
 export async function getMatchday(leagueCode: string): Promise<IFixtureJson[]> {
   const start = dayjs().subtract(3, 'day').format('YYYY-MM-DD')
@@ -67,22 +68,8 @@ async function callApi(url: string, placeholder: string, expiry: number): Promis
     return response
   } catch (error) {
     spinner.error()
-    handleError(error)
+    throw error
   }
-}
-
-function handleError(error: any): void {
-  if (error.response) {
-    console.log(error.response.data.error)
-    console.log(error.response.status)
-  } else if (error.request) {
-    console.log(error.request)
-  } else if (error.message) {
-    console.log('Error', error.message)
-  } else {
-    console.log(error)
-  }
-  process.exit(1)
 }
 
 function apiKeyError(): void {
@@ -90,13 +77,5 @@ function apiKeyError(): void {
     return
   }
 
-  console.error(`
-  SOCCER_GO_API_KEY environment variable not set.
-
-      $ export SOCCER_GO_API_KEY=<football_data_api_key>
-
-  You can get your own API key over at
-  https://www.football-data.org/client/register
-  `)
-  process.exit(1)
+  throw new ApplicationError(ErrorCode.API_KEY_MISSING)
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -3,7 +3,7 @@ import { createSpinner } from 'nanospinner'
 import { cachedApiCall } from './cache'
 import cfg from './config'
 import { IFixtureJson, IStandingsJson, ITeamJson, Team } from './models'
-import { ApplicationError, ErrorCode } from './utils/errors'
+import { ApplicationError, ErrorCode, isErrorNodeSystemError } from './utils/errors'
 
 export async function getMatchday(leagueCode: string): Promise<IFixtureJson[]> {
   const start = dayjs().subtract(3, 'day').format('YYYY-MM-DD')
@@ -51,7 +51,7 @@ export async function getTeamId(teamName: string, leagueCode: string): Promise<n
   const teams = await getCompetitionTeams(leagueCode)
   const team = teams.find((t) => t.name.toLowerCase().includes(teamName.toLowerCase().trim()))
   if (team == null) {
-    throw new Error('Team not found.')
+    throw new ApplicationError(ErrorCode.TEAM_NOT_FOUND, teamName)
   }
   return team.id
 }
@@ -66,8 +66,15 @@ async function callApi(url: string, placeholder: string, expiry: number): Promis
     const response = await cachedApiCall(url, cfg.authToken, expiry)
     spinner.success().clear()
     return response
-  } catch (error) {
+  } catch (error: unknown) {
     spinner.error()
+    if (
+      isErrorNodeSystemError(error) &&
+      error.code === 'ENOTFOUND' &&
+      error.syscall === 'getaddrinfo'
+    ) {
+      throw new ApplicationError(ErrorCode.NETWORK_UNREACHABLE)
+    }
     throw error
   }
 }

--- a/src/cache/Cache.ts
+++ b/src/cache/Cache.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import cfg from '../config'
 import CacheItem from './CacheItem'
+import { ApplicationError, ErrorCode } from '../utils/errors'
 
 type Data = Map<string, CacheItem>
 
@@ -19,7 +20,7 @@ export default class Cache {
         this.data = new Map<string, CacheItem>()
         fs.writeFileSync(this.file, JSON.stringify(Array.from(this.data)))
       } else {
-        throw error
+        throw new ApplicationError(ErrorCode.CACHE_WRITE)
       }
     }
   }

--- a/src/commands/fixtures.ts
+++ b/src/commands/fixtures.ts
@@ -6,8 +6,8 @@ import { FixturesTableBuilder } from '../tableBuilders'
 
 export const printMatchday = async (leagueCode: string): Promise<void> => {
   const league = getLeagueByCode(leagueCode)
-  cfonts.say(league.name)
   const fixturesData = await api.getMatchday(league.code)
+  cfonts.say(league.name)
   const table = new FixturesTableBuilder().buildTable(fixturesData, Fixture)
   console.log(table.toString())
 }

--- a/src/commands/standings.ts
+++ b/src/commands/standings.ts
@@ -7,8 +7,8 @@ import { StandingsTableBuilder } from '../tableBuilders'
 
 export const printStandings = async (leagueCode: string): Promise<void> => {
   const league = getLeagueByCode(leagueCode)
-  cfonts.say(league.name)
   const standingsData = await api.getStandings(leagueCode)
+  cfonts.say(league.name)
   for (const standing of standingsData) {
     if (standing.group) {
       const [, group] = standing.group.split('_')

--- a/src/commands/team.ts
+++ b/src/commands/team.ts
@@ -9,12 +9,14 @@ export const printTeam = async (
   leagueCode: string,
 ): Promise<void> => {
   const team = await fetchTeam(teamName, leagueCode)
-  cfonts.say(team.shortName || team.name)
 
   if (options.includes('Fixtures')) {
     const fixturesData = await api.getTeamFixtures(team)
     const table = new FixturesTableBuilder().buildTable(fixturesData, Fixture)
+    cfonts.say(team.shortName || team.name)
     console.log(table.toString())
+  } else {
+    cfonts.say(team.shortName || team.name)
   }
 
   if (options.includes('Players')) {

--- a/src/commands/team.ts
+++ b/src/commands/team.ts
@@ -24,12 +24,7 @@ export const printTeam = async (
 }
 
 async function fetchTeam(team: string, league: string): Promise<Team> {
-  try {
-    const teamId = await api.getTeamId(team, league)
-    const teamData = await api.getTeam(teamId)
-    return new Team(teamData)
-  } catch (error: any) {
-    console.log(error.message)
-    process.exit(1)
-  }
+  const teamId = await api.getTeamId(team, league)
+  const teamData = await api.getTeam(teamId)
+  return new Team(teamData)
 }

--- a/src/constants/leagues.ts
+++ b/src/constants/leagues.ts
@@ -1,3 +1,5 @@
+import { ApplicationError, ErrorCode } from '../utils/errors'
+
 export interface ILeague {
   code: string
   name: string
@@ -36,7 +38,7 @@ export const getLeagueByName = (name: string): ILeague => {
   if (candidate) {
     return candidate
   }
-  throw new Error('League not found')
+  throw new ApplicationError(ErrorCode.LEAGUE_NOT_FOUND_BY_NAME, name)
 }
 
 export const getLeagueByCode = (code: string): ILeague => {
@@ -44,5 +46,5 @@ export const getLeagueByCode = (code: string): ILeague => {
   if (candidate) {
     return candidate
   }
-  throw new Error('League not found')
+  throw new ApplicationError(ErrorCode.LEAGUE_NOT_FOUND_BY_CODE, code)
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -6,7 +6,6 @@ export const isErrorNodeSystemError = (error: unknown): error is NodeJS.ErrnoExc
     'code' in (error as never) &&
     'errno' in (error as never) &&
     'code' in (error as never) &&
-    'path' in (error as never) &&
     'syscall' in (error as never)
   )
 }
@@ -15,12 +14,30 @@ export enum ErrorCode {
   GENERIC = 1000,
   COMMAND_UNKNOWN,
   API_KEY_MISSING,
+  API_KEY_INVALID,
+  API_RESPONSE_400,
+  API_RESPONSE_429,
+  API_RESPONSE_500,
+  LEAGUE_NOT_FOUND_BY_NAME,
+  LEAGUE_NOT_FOUND_BY_CODE,
+  TEAM_NOT_FOUND,
+  CACHE_WRITE,
+  NETWORK_UNREACHABLE,
 }
 
 export class ApplicationError extends Error {
   constructor(code: ErrorCode.GENERIC, message: string)
   constructor(code: ErrorCode.COMMAND_UNKNOWN, command: string)
   constructor(code: ErrorCode.API_KEY_MISSING)
+  constructor(code: ErrorCode.API_KEY_INVALID)
+  constructor(code: ErrorCode.API_RESPONSE_400, message: string)
+  constructor(code: ErrorCode.API_RESPONSE_429)
+  constructor(code: ErrorCode.API_RESPONSE_500)
+  constructor(code: ErrorCode.TEAM_NOT_FOUND, teamName: string)
+  constructor(code: ErrorCode.LEAGUE_NOT_FOUND_BY_NAME, leagueName: string)
+  constructor(code: ErrorCode.LEAGUE_NOT_FOUND_BY_CODE, leagueCode: string)
+  constructor(code: ErrorCode.CACHE_WRITE)
+  constructor(code: ErrorCode.NETWORK_UNREACHABLE)
   constructor(public code: ErrorCode, public extraData?: string) {
     super()
   }
@@ -41,6 +58,41 @@ export const formatErrorForPrinting = (code: ErrorCode, extraData?: string): str
         'You can get your own API key over at\n' +
         'https://www.football-data.org/client/register\n'
       )
+
+    case ErrorCode.API_KEY_INVALID:
+      return (
+        'The API key set is invalid.\n' +
+        'Please check that the SOCCER_GO_API_KEY environment variable matches ' +
+        'the key you received upon registration\n\n' +
+        '    $ echo $SOCCER_GO_API_KEY\n'
+      )
+
+    case ErrorCode.API_RESPONSE_400:
+      return `Something went wrong with your request, reason:\n\n    ${extraData}\n`
+
+    case ErrorCode.API_RESPONSE_429:
+      return (
+        'You seem to have made too many requests.\n' +
+        'Please wait a minute before making new requests.\n'
+      )
+
+    case ErrorCode.API_RESPONSE_500:
+      return 'Cannot retrieve data at this time, please try again later.\n'
+
+    case ErrorCode.LEAGUE_NOT_FOUND_BY_NAME:
+      return `Could not find league "${extraData}".\n`
+
+    case ErrorCode.LEAGUE_NOT_FOUND_BY_CODE:
+      return `Could not find league with code "${extraData}".\n`
+
+    case ErrorCode.TEAM_NOT_FOUND:
+      return `Could not find team "${extraData}".\n`
+
+    case ErrorCode.CACHE_WRITE:
+      return `There was an issue when attempting to write data to cache.\n`
+
+    case ErrorCode.NETWORK_UNREACHABLE:
+      return 'Could not contact the server.\nPlease check your connection settings.\n'
   }
 }
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -10,3 +10,53 @@ export const isErrorNodeSystemError = (error: unknown): error is NodeJS.ErrnoExc
     'syscall' in (error as never)
   )
 }
+
+export enum ErrorCode {
+  GENERIC = 1000,
+  COMMAND_UNKNOWN,
+  API_KEY_MISSING,
+}
+
+export class ApplicationError extends Error {
+  constructor(code: ErrorCode.GENERIC, message: string)
+  constructor(code: ErrorCode.COMMAND_UNKNOWN, command: string)
+  constructor(code: ErrorCode.API_KEY_MISSING)
+  constructor(public code: ErrorCode, public extraData?: string) {
+    super()
+  }
+}
+
+export const formatErrorForPrinting = (code: ErrorCode, extraData?: string): string => {
+  switch (code) {
+    case ErrorCode.GENERIC:
+      return `Something unexpected happened:\n     ${extraData}\n`
+
+    case ErrorCode.COMMAND_UNKNOWN:
+      return `Unknown command "${extraData}".\n`
+
+    case ErrorCode.API_KEY_MISSING:
+      return (
+        'SOCCER_GO_API_KEY environment variable not set.\n\n' +
+        '    $ export SOCCER_GO_API_KEY=<football_data_api_key>\n\n' +
+        'You can get your own API key over at\n' +
+        'https://www.football-data.org/client/register\n'
+      )
+  }
+}
+
+export const handleCommandError = (error: unknown): void => {
+  if (error instanceof ApplicationError) {
+    console.error(formatErrorForPrinting(error.code, error.extraData))
+    process.exit(error.code)
+  }
+
+  if (error instanceof Error) {
+    console.error(formatErrorForPrinting(ErrorCode.GENERIC, error.message))
+    process.exit(ErrorCode.GENERIC)
+  }
+
+  if (typeof error === 'string') {
+    console.error(formatErrorForPrinting(ErrorCode.GENERIC, error))
+    process.exit(ErrorCode.GENERIC)
+  }
+}

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -92,7 +92,7 @@ export const formatErrorForPrinting = (code: ErrorCode, extraData?: string): str
       return `There was an issue when attempting to write data to cache.\n`
 
     case ErrorCode.NETWORK_UNREACHABLE:
-      return 'Could not contact the server.\nPlease check your connection settings.\n'
+      return 'Could not contact the server.\nPlease check your internet connection.\n'
   }
 }
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -21,7 +21,6 @@ export enum ErrorCode {
   LEAGUE_NOT_FOUND_BY_NAME,
   LEAGUE_NOT_FOUND_BY_CODE,
   TEAM_NOT_FOUND,
-  CACHE_WRITE,
   NETWORK_UNREACHABLE,
 }
 
@@ -36,7 +35,6 @@ export class ApplicationError extends Error {
   constructor(code: ErrorCode.TEAM_NOT_FOUND, teamName: string)
   constructor(code: ErrorCode.LEAGUE_NOT_FOUND_BY_NAME, leagueName: string)
   constructor(code: ErrorCode.LEAGUE_NOT_FOUND_BY_CODE, leagueCode: string)
-  constructor(code: ErrorCode.CACHE_WRITE)
   constructor(code: ErrorCode.NETWORK_UNREACHABLE)
   constructor(public code: ErrorCode, public extraData?: string) {
     super()
@@ -87,9 +85,6 @@ export const formatErrorForPrinting = (code: ErrorCode, extraData?: string): str
 
     case ErrorCode.TEAM_NOT_FOUND:
       return `Could not find team "${extraData}".\n`
-
-    case ErrorCode.CACHE_WRITE:
-      return `There was an issue when attempting to write data to cache.\n`
 
     case ErrorCode.NETWORK_UNREACHABLE:
       return 'Could not contact the server.\nPlease check your internet connection.\n'


### PR DESCRIPTION
This PR is a proposal for improving error management and how such errors are displayed to the user. It addresses #17.

There are two major steps involved, plus some small UX changes for consistency.

## 1. Streamline how errors are surfaced and managed
Necessary changes are made so that all unrecoverable errors eventually bubble up `src/index.ts` because it's easier to handle errors in one place. This means that all existing `process.exit` calls in other files, like in `src/api.ts` and `src/commands/team.ts`, are removed.

In other words, all commands can throw errors and they are captured in `src/index.ts`.

All errors are handled with the newly added `handleCommandError` function. This function will interpret the errors to pick an appropriate error message to display and an error code to use with `process.exit`. To make this easier, `ApplicationError` is created (next step).

## 2. Unified error class `ApplicationError`
`ApplicationError` is an extension of `Error` and is designed to be used for unrecoverable errors. It is used to convey the nature of the error and have extra contextual info (for certain types of errors).

## Small UX changes
### Don't use cfonts until all data is available
Seeing a giant piece of text is noisy when in fact the application encounters an error, it is not useful. It might even initially give the illusion that "it's working". So, cfonts is now used only if all the API data has been fetched correctly.

**Before**
![Screenshot from 2023-05-06 11-04-43](https://user-images.githubusercontent.com/1713151/236616395-7fb09b68-cbac-4d65-b992-2c6a04246bb4.png)

**After**
![Screenshot from 2023-05-06 11-41-50](https://user-images.githubusercontent.com/1713151/236616462-1f1fc9f5-b9d7-4d95-9be5-3d92eff49d9b.png)

### Display an error spinner even when no API key is available.
Previously, the spinner would not be displayed at all if there is no API key available, even if though the application is in the data fetching phase.

## Things that need improving before merging
Most of the error messages of `formatErrorForPrinting` probably need refining, rephrasing, and spellchecking as for now they are sort of placeholders. Feedback is much appreciated.