### PR TITLE
Bump cfonts dependency with typings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
-        "cfonts": "^3.1.1",
+        "cfonts": "^3.2.0",
         "cli-table3": "^0.5.1",
         "commander": "^3.0.2",
         "dayjs": "^1.11.7",
@@ -2279,9 +2279,9 @@
       "integrity": "sha512-dgh+YleemrT8u85QL11Z6tYhegAs3MMxsaWAq/oXeAmYJ7VxL3SI9TZtnfaEvNDMAPolj25FXIb3S+HCI4wQaQ=="
     },
     "node_modules/cfonts": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/cfonts/-/cfonts-3.1.1.tgz",
-      "integrity": "sha512-PFknL/y+QVzoVmnm4X/PLd+t5Bt4aSvFBebpvyjcVUb81jHIVHFKvAopADbTk9tnfLLC2RHFZgdVa9YAwQp1mw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cfonts/-/cfonts-3.2.0.tgz",
+      "integrity": "sha512-CFGxRY6aBuOgK85bceCpmMMhuyO6IwcAyyeapB//DtRzm7NbAEsDuuZzBoQxVonz+C2BmZ3swqB/YgcmW+rh3A==",
       "dependencies": {
         "supports-color": "^8",
         "window-size": "^1.1.1"
@@ -8573,9 +8573,9 @@
       "integrity": "sha512-dgh+YleemrT8u85QL11Z6tYhegAs3MMxsaWAq/oXeAmYJ7VxL3SI9TZtnfaEvNDMAPolj25FXIb3S+HCI4wQaQ=="
     },
     "cfonts": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/cfonts/-/cfonts-3.1.1.tgz",
-      "integrity": "sha512-PFknL/y+QVzoVmnm4X/PLd+t5Bt4aSvFBebpvyjcVUb81jHIVHFKvAopADbTk9tnfLLC2RHFZgdVa9YAwQp1mw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cfonts/-/cfonts-3.2.0.tgz",
+      "integrity": "sha512-CFGxRY6aBuOgK85bceCpmMMhuyO6IwcAyyeapB//DtRzm7NbAEsDuuZzBoQxVonz+C2BmZ3swqB/YgcmW+rh3A==",
       "requires": {
         "supports-color": "^8",
         "window-size": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "start": "ts-node --files src/index.ts"
   },
   "dependencies": {
-    "cfonts": "^3.1.1",
+    "cfonts": "^3.2.0",
     "cli-table3": "^0.5.1",
     "commander": "^3.0.2",
     "dayjs": "^1.11.7",

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -1,5 +1,0 @@
-// Packages without type definitions.
-declare module 'cfonts'
-
-// Binary assets and text-based files.
-declare module '*.json'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@tsconfig/node10/tsconfig.json",
   "compilerOptions": {
     "declaration": true,
-    "outDir": "./lib"
+    "outDir": "./lib",
+    "resolveJsonModule": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "**/*spec.ts"]


### PR DESCRIPTION
My cfonts PR to add TS declarations was just merged, and now version 3.2.0 includes typings. Its ambient module definition in `custom.d.ts` is not required anymore.

Also, since TypeScript has a flag to allow importing JSON files, `custom.d.ts` is no longer required.