### PR TITLE
Limit rimraf version to 3.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,7 @@ updates:
         # Starting from version 8, Commander.js bumped their min Node.js version to 12.
       - dependency-name: "commander"
         versions: [">=8.0.0"]
+
+      # Starting from version 4, rimraf bumped their min Node.js version to 14.
+      - dependency-name: "rimraf"
+        versions: [">=4.0.0"]


### PR DESCRIPTION
Starting from version 4, rimraf dropped support for Node.js below version 14 and, in fact, workflows for PR
https://github.com/acifani/soccer-go/pull/388 shows that v5 fails to run on version 10 while version 14 and above succeeded.